### PR TITLE
Fix for python 3.7 & using TensorBoard Callback

### DIFF
--- a/optkeras/optkeras.py
+++ b/optkeras/optkeras.py
@@ -5,6 +5,7 @@ import os, glob
 import numpy as np
 from datetime import datetime
 from pathlib import Path
+from inspect import signature
 
 import optuna
 
@@ -302,8 +303,6 @@ class OptKeras(Callback):
         self.datetime_epoch_end = self.get_datetime()
         # Add error and val_error to logs for use as an objective to minimize
 
-        logs['_Datetime_epoch_begin'] = self.datetime_epoch_begin
-        logs['_Datetime_epoch_end'] = self.datetime_epoch_end
         logs['_Trial_num'] = self.trial.number
         # Update the best logs
 
@@ -364,7 +363,7 @@ class OptKeras(Callback):
 
 
 def get_trial_default():
-    num_fields = optuna.structs.FrozenTrial._field_types.__len__()
+    num_fields = len(signature(optuna.structs.FrozenTrial).parameters)
     assert num_fields in (10, 11, 12)
     if num_fields == 12: # possible future version
         return optuna.structs.FrozenTrial(


### PR DESCRIPTION
In python 3.7 there is no _field_types I suppose so it didn't work with optuna.
Using signature.params did the trick for me.

Using TensorBoard Callback with optkeras resulted in error:

Original exception was: Traceback (most recent call last): File "optimize.py", line 216, in <module> ok.optimize(objective, n_trials=50) File "/home/user/virtualenvs/tf1-py37/lib/python3.7/site-packages/optkeras/optkeras.py", line 135, in optimize self.study.optimize(*args, **kwargs) File "/home/user/.local/lib/python3.7/site-packages/optuna/study.py", line 261, in optimize gc_after_trial) File "/home/user/.local/lib/python3.7/site-packages/optuna/study.py", line 443, in _optimize_sequential self._run_trial_and_callbacks(func, catch, callbacks, gc_after_trial) File "/home/user/.local/lib/python3.7/site-packages/optuna/study.py", line 520, in _run_trial_and_callbacks trial = self._run_trial(func, catch, gc_after_trial) File "/home/user/.local/lib/python3.7/site-packages/optuna/study.py", line 539, in _run_trial result = func(trial) File "/home/user/virtualenvs/tf1-py37/lib/python3.7/site-packages/optkeras/optkeras.py", line 131, in fun_tf return fun(trial) File "optimize.py", line 210, in objective class_weight=class_weights) File "/home/user/virtualenvs/tf1-py37/lib/python3.7/site-packages/keras/legacy/interfaces.py", line 91, in wrapper return func(*args, **kwargs) File "/home/user/virtualenvs/tf1-py37/lib/python3.7/site-packages/keras/engine/training.py", line 1658, in fit_generator initial_epoch=initial_epoch) File "/home/user/virtualenvs/tf1-py37/lib/python3.7/site-packages/keras/engine/training_generator.py", line 255, in fit_generator callbacks.on_epoch_end(epoch, epoch_logs) File "/home/user/virtualenvs/tf1-py37/lib/python3.7/site-packages/keras/callbacks.py", line 152, in on_epoch_end callback.on_epoch_end(epoch, logs) File "/home/user/virtualenvs/tf1-py37/lib/python3.7/site-packages/keras/callbacks.py", line 1259, in on_epoch_end self._write_logs(logs, index) File "/home/user/virtualenvs/tf1-py37/lib/python3.7/site-packages/keras/callbacks.py", line 1270, in _write_logs summary_value.simple_value = value TypeError: '2019-12-09 22:36:08.838879' has type str, but expected one of: int, long, float